### PR TITLE
Added TLS copy certificate commands and params #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains the scripts for deploying a Hyperledger Fabric Network.
 # Note for Docker for macOS
 IMPORTANT: gRPC FUSE-Option MUST be deactivated in Docker Desktop and Docker restarted or Chaincode Installation will NOT work!
 (Link to Jira Issue)[https://jira.hyperledger.org/browse/FAB-18134]
+It is possible that the Chaincode deployment will not work on macOS due to the above issue (it only works when gRPC FUSE is activated).
 
 # Hyperledger Fabric version 1.x
 Please see the fabric-version1x folder 

--- a/fabric-version2x/creatingCryptoMaterial/create_crypto_peer_organisation.sh
+++ b/fabric-version2x/creatingCryptoMaterial/create_crypto_peer_organisation.sh
@@ -7,7 +7,7 @@
 # This work is licensed under a Creative Commons Attribution 4.0 International License
 # (http://creativecommons.org/licenses/by/4.0/).
 #
-# Author(s): Tim Reimers, Andreas Hermann
+# Author(s): Tim Reimers, Andreas Hermann, Razvan Hrestic
 # NutriSafe Research Project
 # Institute for Protection and Dependability
 # Department of Computer Science
@@ -31,6 +31,7 @@ function printHelp() {
   echo "Usage: "
   echo "  create_crypto_for_peer_organisation.sh <[-f <path for .yaml file>]>"
   echo "    -f <Path to .yaml File> - specify yaml path"
+  echo "    -d <DNS-like Domain Name> - specify organization domain e.g. brangus.de"
   echo "  create_crypto_for_peer_organisation.sh -h (print this message)"
 }
 
@@ -38,7 +39,7 @@ function printHelp() {
 # Section:      Parameters
 # Description:  List of script parameters
 # -------------------------------------------------------------------------------------------------------------------
-while getopts "h?f:x" opt; do
+while getopts "h?f:d:x" opt; do
   case "$opt" in
   h | \?)
     printHelp
@@ -47,19 +48,27 @@ while getopts "h?f:x" opt; do
   f)
     PATH_TO_YAML_FILE=$OPTARG
     ;;
+  d)
+    ORGANIZATION_DOMAIN=$OPTARG
+    ;;
   esac
 done
 
 # -------------------------------------------------------------------------------------------------------------------
-# Section:      cryptogren generate
-# Description:  Generate crypto material for organisation
-# Parameter:    $PATH_TO_YAML_FILE
-# Example:      create_crypto_for_peer_organisation.sh -f ./crypto_config_ilda.yaml
+# Section:      cryptogen extend 
+# Description:  Generates crypto material for a given peer organisation, checks first to see if it was previously generated
+# Parameter:    $PATH_TO_YAML_FILE, $ORGANISATION_DOMAIN
+# Example:      create_crypto_for_peer_organisation.sh -f ./crypto_config_ilda.yaml -d ilda.de
 # -------------------------------------------------------------------------------------------------------------------
-rm -rf "./crypto-config/"$ORGANISATION_TYPE"/"$ORGANISATION_DOMAIN/*
+# Global parameter: Name of admin user for said organization
+# RM command below is faulty.
+#rm -rf "./crypto-config/"$ORGANISATION_TYPE"/"$ORGANISATION_DOMAIN/*
 
-if cryptogen generate --config=$PATH_TO_YAML_FILE ; then
+if cryptogen extend --config=$PATH_TO_YAML_FILE ; then
   echo "Successfully generated crypto material!"
+  echo "Copying public certificates for Admin user..."
+  cp "./crypto-config/"$ORGANISATION_TYPE"s/"$ORGANISATION_DOMAIN/tlsca/tlsca.$ORGANISATION_DOMAIN"-cert.pem" "./crypto-config/"$ORGANISATION_TYPE"s/"$ORGANISATION_DOMAIN/users/"Admin@"$ORGANISATION_DOMAIN/tls/tlsca.$ORGANISATION_DOMAIN"-cert.pem"
+  cp "./crypto-config/ordererOrganizations/unibw.de/tlsca/tlsca.unibw.de-cert.pem" "./crypto-config/"$ORGANISATION_TYPE"s/"$ORGANISATION_DOMAIN/users/"Admin@"$ORGANISATION_DOMAIN/tls/tlsca.unibw.de"-cert.pem"
 else
   echo "Something went wrong with the crypto material generation, please check output and logs."
 fi


### PR DESCRIPTION
See #11 for details. Added a parameter for create_crypto_peer_organisation.sh in order to avoid unnecessarily re-generating certificates for new Orgs and to copy needed unibw und Orga TLS certs into the Admin user folder (assumption: Admin user is always called Admin).